### PR TITLE
adds commentstring configuration

### DIFF
--- a/ftplugin/noir.lua
+++ b/ftplugin/noir.lua
@@ -1,1 +1,6 @@
-vim.lsp.start({ cmd = {'nargo', 'lsp'}, root_dir = vim.fs.dirname(vim.fs.find({'Nargo.toml'}, {stop = vim.env.HOME})[1]), })
+vim.lsp.start({
+	cmd = { "nargo", "lsp" },
+	root_dir = vim.fs.dirname(vim.fs.find({ "Nargo.toml" }, { stop = vim.env.HOME })[1]),
+})
+
+vim.bo.commentstring = "// %s"


### PR DESCRIPTION
# Description

Adds `commentstring` configuration  for commenting code with hotkeys instead of typing

## Problem\*

currently using the "comment line" hotkey does not work and outputs the message
`Option 'commentstring' is empty.`

## Summary\*

## Additional Context


# PR Checklist\*

- [ x ] I have tested the changes locally.
- [ x ] I have formatted the changes with [Prettier](https://prettier.io/) and/or `cargo fmt` on default settings.
